### PR TITLE
6503 pg heron front end vunerabilities

### DIFF
--- a/src/main/groovy/kumc_bmi/StudyTeam.groovy
+++ b/src/main/groovy/kumc_bmi/StudyTeam.groovy
@@ -105,14 +105,14 @@ class CLI {
 *    }
 */
     boolean flag(String it) {
-        args.contains(it)
+        args_given.contains(it)
     }
     
     def arg(String sentinel, Closure thunk) {
-        def i = (args as List).findIndexOf { it == sentinel }
-        def l = args.length
+        def i = (args_given as List).findIndexOf { it == sentinel }
+        def l = args_given.length
         if (i >= 0 && i + 1 < l) {
-            thunk(args[i + 1]);
+            thunk(args_given[i + 1]);
         } else if (i >= 0) {
             System.err.println("$sentinel requires value argument")
         }

--- a/src/main/groovy/kumc_bmi/StudyTeam.groovy
+++ b/src/main/groovy/kumc_bmi/StudyTeam.groovy
@@ -99,10 +99,11 @@ class CLI {
     String[] args_given
     
     CLI(args1) {
-      String[] raw_args
       /*raw_args = args1.toArray(new String[args1.size()]);*/
-      this.logger.warning(args1.toString())
-      this.args_given = args_given.toString().split(',')
+      ArrayList<String> raw_args = ArrayList<String>(args1)
+      str_eq_raw_args = raw_args.toArray(new String[raw_args.size()]);
+      this.logger.warning(str_eq_raw_args.toString())
+      this.args_given = str_eq_raw_args
     }
 
     boolean flag(String it) {

--- a/src/main/groovy/kumc_bmi/StudyTeam.groovy
+++ b/src/main/groovy/kumc_bmi/StudyTeam.groovy
@@ -10,7 +10,6 @@ import java.sql.SQLFeatureNotSupportedException
 import java.util.logging.Logger
 import static java.util.logging.Level.SEVERE
 import javax.sql.DataSource
-import commandLine.CLI 
 
 import com.sun.net.httpserver.HttpExchange
 import com.sun.net.httpserver.HttpServer

--- a/src/main/groovy/kumc_bmi/StudyTeam.groovy
+++ b/src/main/groovy/kumc_bmi/StudyTeam.groovy
@@ -101,7 +101,7 @@ class CLI {
     CLI(args_given) {
       def raw_args = Eval.me(args_given.toString())
       assert raw_args.class == String[]  
-      logger.critical(raw_args)
+      logger.SEVERE(raw_args)
       this.args = raw_args
     }
 

--- a/src/main/groovy/kumc_bmi/StudyTeam.groovy
+++ b/src/main/groovy/kumc_bmi/StudyTeam.groovy
@@ -95,7 +95,7 @@ class StudyTeam {
 @Immutable
 @CompileStatic
 class CLI {
-    private Logger logger = Logger.getLogger("")
+/*    private Logger logger = Logger.getLogger("")*/
     String[] args_given
     
 /**    CLI(args_given) {

--- a/src/main/groovy/kumc_bmi/StudyTeam.groovy
+++ b/src/main/groovy/kumc_bmi/StudyTeam.groovy
@@ -101,7 +101,7 @@ class CLI {
     CLI(args_given) {
       def raw_args = Eval.me(args_given.toString())
       assert raw_args.class == String[]  
-      logger.SEVERE(raw_args)
+      logger.warn(raw_args)
       this.args = raw_args
     }
 

--- a/src/main/groovy/kumc_bmi/StudyTeam.groovy
+++ b/src/main/groovy/kumc_bmi/StudyTeam.groovy
@@ -98,7 +98,9 @@ class CLI {
     String[] args
     
     CLI(args_given) {          
-        this.args = Eval.me(args_given.toString())
+      def raw_args = Eval.me(args_given.toString())
+      assert raw_args.class == String[]  
+      this.args = raw_args
     }
 
     boolean flag(String it) {

--- a/src/main/groovy/kumc_bmi/StudyTeam.groovy
+++ b/src/main/groovy/kumc_bmi/StudyTeam.groovy
@@ -28,7 +28,7 @@ class StudyTeam {
         def fail = { ex -> System.err.println(ex); System.exit(1) }
         def dbAccess = { String u, Properties p -> DriverManager.getConnection(u, p) }
         def listen = { InetSocketAddress a, int b -> HttpServer.create(a, b) }
-        run(new CLI(args: args), System.out, fail, dbAccess, listen)
+        run(new CLI(args), System.out, fail, dbAccess, listen)
     }
 
     public static void run(CLI cli, PrintStream out,
@@ -94,11 +94,15 @@ class StudyTeam {
 @CompileStatic
 class CLI {
     String[] args
+    
+    CLI(args_given) {          
+        this.args = args.addAll(args_given)
+    }
 
     boolean flag(String it) {
         args.contains(it)
     }
-
+    
     def arg(String sentinel, Closure thunk) {
         def i = (args as List).findIndexOf { it == sentinel }
         def l = args.length

--- a/src/main/groovy/kumc_bmi/StudyTeam.groovy
+++ b/src/main/groovy/kumc_bmi/StudyTeam.groovy
@@ -100,8 +100,8 @@ class CLI {
     
     CLI(args_given) {
       raw_args = args_given.toArray(new String[args_given.size()]);
-      this.logger.warning(raw_args)
-      this.args = raw_args
+      this.logger.warning(args_given.toString())
+      this.args = args_given.toString().split(',')
     }
 
     boolean flag(String it) {

--- a/src/main/groovy/kumc_bmi/StudyTeam.groovy
+++ b/src/main/groovy/kumc_bmi/StudyTeam.groovy
@@ -92,7 +92,7 @@ class StudyTeam {
 }
 
 
-/*@Immutiable*/
+/*@Immutable*/
 @CompileStatic
 class CLI {
     private Logger logger = Logger.getLogger("")

--- a/src/main/groovy/kumc_bmi/StudyTeam.groovy
+++ b/src/main/groovy/kumc_bmi/StudyTeam.groovy
@@ -99,7 +99,7 @@ class CLI {
     String[] args
     
     CLI(args_given) {
-      this.logger.warning(args)
+      this.logger.warning(args_given)
       this.args = raw_args
     }
 

--- a/src/main/groovy/kumc_bmi/StudyTeam.groovy
+++ b/src/main/groovy/kumc_bmi/StudyTeam.groovy
@@ -97,7 +97,7 @@ class CLI {
     String[] args
     
     CLI(args_given) {          
-        this.args = args
+        this.args = args_given
     }
 
     boolean flag(String it) {

--- a/src/main/groovy/kumc_bmi/StudyTeam.groovy
+++ b/src/main/groovy/kumc_bmi/StudyTeam.groovy
@@ -18,7 +18,6 @@ import groovy.json.JsonOutput
 import groovy.sql.Sql
 import groovy.transform.CompileStatic
 import groovy.transform.Immutable
-import groovy.util.Eval.*
 
 @Immutable
 @CompileStatic
@@ -96,25 +95,24 @@ class StudyTeam {
 @CompileStatic
 class CLI {
     private Logger logger = Logger.getLogger("")
-    String[] args_given
+    String[] args
     
     CLI(args1) {
       /*raw_args = args1.toArray(new String[args1.size()]);*/
       ArrayList<String> raw_args = (ArrayList<String>)args1
       String[] str_eq_raw_args = raw_args.toArray(new String[raw_args.size()]);
       this.logger.warning(str_eq_raw_args.toString())
-      this.args_given = str_eq_raw_args
+      this.args = str_eq_raw_args
     }
 
     boolean flag(String it) {
-        args_given.contains(it)
-    }
-    
+        args.contains(it)
+    }   
     def arg(String sentinel, Closure thunk) {
-        def i = (args_given as List).findIndexOf { it == sentinel }
-        def l = args_given.length
+        def i = (args as List).findIndexOf { it == sentinel }
+        def l = args.length
         if (i >= 0 && i + 1 < l) {
-            thunk(args_given[i + 1]);
+            thunk(args[i + 1]);
         } else if (i >= 0) {
             System.err.println("$sentinel requires value argument")
         }

--- a/src/main/groovy/kumc_bmi/StudyTeam.groovy
+++ b/src/main/groovy/kumc_bmi/StudyTeam.groovy
@@ -10,6 +10,7 @@ import java.sql.SQLFeatureNotSupportedException
 import java.util.logging.Logger
 import static java.util.logging.Level.SEVERE
 import javax.sql.DataSource
+import commandLine.CLI 
 
 import com.sun.net.httpserver.HttpExchange
 import com.sun.net.httpserver.HttpServer

--- a/src/main/groovy/kumc_bmi/StudyTeam.groovy
+++ b/src/main/groovy/kumc_bmi/StudyTeam.groovy
@@ -101,7 +101,7 @@ class CLI {
     CLI(args1) {
       /*raw_args = args1.toArray(new String[args1.size()]);*/
       ArrayList<String> raw_args = (ArrayList<String>)args1
-      str_eq_raw_args = raw_args.toArray(new String[raw_args.size()]);
+      String[] str_eq_raw_args = raw_args.toArray(new String[raw_args.size()]);
       this.logger.warning(str_eq_raw_args.toString())
       this.args_given = str_eq_raw_args
     }

--- a/src/main/groovy/kumc_bmi/StudyTeam.groovy
+++ b/src/main/groovy/kumc_bmi/StudyTeam.groovy
@@ -95,6 +95,7 @@ class StudyTeam {
 
 @CompileStatic
 class CLI {
+    private Logger logger = Logger.getLogger("")
     String[] args
     
     CLI(args_given) {

--- a/src/main/groovy/kumc_bmi/StudyTeam.groovy
+++ b/src/main/groovy/kumc_bmi/StudyTeam.groovy
@@ -29,8 +29,8 @@ class StudyTeam {
         def fail = { ex -> System.err.println(ex); System.exit(1) }
         def dbAccess = { String u, Properties p -> DriverManager.getConnection(u, p) }
         def listen = { InetSocketAddress a, int b -> HttpServer.create(a, b) }
-        CLI cli = new CLI(args)
-        run(cli, System.out, fail, dbAccess, listen)
+       /* CLI cli = new CLI(args)*/
+        run(new CLI(args_given: args), System.out, fail, dbAccess, listen)
     }
 
     public static void run(CLI cli, PrintStream out,
@@ -92,18 +92,18 @@ class StudyTeam {
 }
 
 
-
+@Immutable
 @CompileStatic
 class CLI {
     private Logger logger = Logger.getLogger("")
-    String[] args
+    String[] args_given
     
-    CLI(args_given) {
-      raw_args = args_given.toArray(new String[args_given.size()]);
-      this.logger.warning(args_given.toString())
-      this.args = args_given.toString().split(',')
-    }
-
+/**    CLI(args_given) {
+*      raw_args = args_given.toArray(new String[args_given.size()]);
+*      this.logger.warning(args_given.toString())
+*      this.args_given = args_given.toString().split(',')
+*    }
+*/
     boolean flag(String it) {
         args.contains(it)
     }

--- a/src/main/groovy/kumc_bmi/StudyTeam.groovy
+++ b/src/main/groovy/kumc_bmi/StudyTeam.groovy
@@ -99,7 +99,7 @@ class CLI {
     String[] args
     
     CLI(args_given) {
-      this.logger.warning(args_given.toSring())
+      this.logger.warning(args_given.toString())
       this.args = raw_args
     }
 

--- a/src/main/groovy/kumc_bmi/StudyTeam.groovy
+++ b/src/main/groovy/kumc_bmi/StudyTeam.groovy
@@ -101,7 +101,7 @@ class CLI {
     CLI(args_given) {
       def raw_args = Eval.me(args_given.toString())
       assert raw_args.class == String[]  
-      logger.warn(raw_args)
+      logger.warning(raw_args)
       this.args = raw_args
     }
 

--- a/src/main/groovy/kumc_bmi/StudyTeam.groovy
+++ b/src/main/groovy/kumc_bmi/StudyTeam.groovy
@@ -100,7 +100,7 @@ class CLI {
     
     CLI(args_given) {
       this.logger.warning(args_given.toString())
-      this.args = raw_args
+      this.args = args_given.toString().split(',')
     }
 
     boolean flag(String it) {

--- a/src/main/groovy/kumc_bmi/StudyTeam.groovy
+++ b/src/main/groovy/kumc_bmi/StudyTeam.groovy
@@ -18,6 +18,7 @@ import groovy.json.JsonOutput
 import groovy.sql.Sql
 import groovy.transform.CompileStatic
 import groovy.transform.Immutable
+import groovy.util.Eval.*
 
 @Immutable
 @CompileStatic
@@ -97,7 +98,7 @@ class CLI {
     String[] args
     
     CLI(args_given) {          
-        this.args = args_given.toString()
+        this.args = Eval.me(args_given.toString())
     }
 
     boolean flag(String it) {

--- a/src/main/groovy/kumc_bmi/StudyTeam.groovy
+++ b/src/main/groovy/kumc_bmi/StudyTeam.groovy
@@ -100,7 +100,7 @@ class CLI {
     
     CLI(args1) {
       /*raw_args = args1.toArray(new String[args1.size()]);*/
-      ArrayList<String> raw_args = ArrayList<String>(args1)
+      ArrayList<String> raw_args = (ArrayList<String>)args1
       str_eq_raw_args = raw_args.toArray(new String[raw_args.size()]);
       this.logger.warning(str_eq_raw_args.toString())
       this.args_given = str_eq_raw_args

--- a/src/main/groovy/kumc_bmi/StudyTeam.groovy
+++ b/src/main/groovy/kumc_bmi/StudyTeam.groovy
@@ -28,7 +28,8 @@ class StudyTeam {
         def fail = { ex -> System.err.println(ex); System.exit(1) }
         def dbAccess = { String u, Properties p -> DriverManager.getConnection(u, p) }
         def listen = { InetSocketAddress a, int b -> HttpServer.create(a, b) }
-        run(new CLI(args), System.out, fail, dbAccess, listen)
+        CLI cli = new CLI(args)
+        run(cli, System.out, fail, dbAccess, listen)
     }
 
     public static void run(CLI cli, PrintStream out,

--- a/src/main/groovy/kumc_bmi/StudyTeam.groovy
+++ b/src/main/groovy/kumc_bmi/StudyTeam.groovy
@@ -99,8 +99,9 @@ class CLI {
     String[] args
     
     CLI(args_given) {
-      this.logger.warning(args_given.toString())
-      this.args = args_given.toString().split(',')
+      raw_args = args_given.toArray(new String[args_given.size()]);
+      this.logger.warning(raw_args)
+      this.args = raw_args
     }
 
     boolean flag(String it) {

--- a/src/main/groovy/kumc_bmi/StudyTeam.groovy
+++ b/src/main/groovy/kumc_bmi/StudyTeam.groovy
@@ -91,7 +91,7 @@ class StudyTeam {
 }
 
 
-@Immutable
+
 @CompileStatic
 class CLI {
     String[] args

--- a/src/main/groovy/kumc_bmi/StudyTeam.groovy
+++ b/src/main/groovy/kumc_bmi/StudyTeam.groovy
@@ -99,8 +99,9 @@ class CLI {
     String[] args_given
     
     CLI(args1) {
-      raw_args = args1.toArray(new String[args1.size()]);
-      this.logger.warning(raw_args)
+      String[] raw_args
+      /*raw_args = args1.toArray(new String[args1.size()]);*/
+      this.logger.warning(args1.toString())
       this.args_given = args_given.toString().split(',')
     }
 

--- a/src/main/groovy/kumc_bmi/StudyTeam.groovy
+++ b/src/main/groovy/kumc_bmi/StudyTeam.groovy
@@ -99,9 +99,7 @@ class CLI {
     String[] args
     
     CLI(args_given) {
-      def raw_args = Eval.me(args_given.toString())
-      assert raw_args.class == String[]  
-      logger.warning(raw_args)
+      this.logger.warning(args)
       this.args = raw_args
     }
 

--- a/src/main/groovy/kumc_bmi/StudyTeam.groovy
+++ b/src/main/groovy/kumc_bmi/StudyTeam.groovy
@@ -29,8 +29,8 @@ class StudyTeam {
         def fail = { ex -> System.err.println(ex); System.exit(1) }
         def dbAccess = { String u, Properties p -> DriverManager.getConnection(u, p) }
         def listen = { InetSocketAddress a, int b -> HttpServer.create(a, b) }
-       /* CLI cli = new CLI(args)*/
-        run(new CLI(args_given: args), System.out, fail, dbAccess, listen)
+        CLI cli = new CLI(args)
+        run(cli, System.out, fail, dbAccess, listen)
     }
 
     public static void run(CLI cli, PrintStream out,
@@ -92,18 +92,18 @@ class StudyTeam {
 }
 
 
-@Immutable
+/*@Immutiable*/
 @CompileStatic
 class CLI {
-/*    private Logger logger = Logger.getLogger("")*/
+    private Logger logger = Logger.getLogger("")
     String[] args_given
     
-/**    CLI(args_given) {
-*      raw_args = args_given.toArray(new String[args_given.size()]);
-*      this.logger.warning(args_given.toString())
-*      this.args_given = args_given.toString().split(',')
-*    }
-*/
+    CLI(args1) {
+      raw_args = args1.toArray(new String[args1.size()]);
+      this.logger.warning(raw_args)
+      this.args_given = args_given.toString().split(',')
+    }
+
     boolean flag(String it) {
         args_given.contains(it)
     }

--- a/src/main/groovy/kumc_bmi/StudyTeam.groovy
+++ b/src/main/groovy/kumc_bmi/StudyTeam.groovy
@@ -1,6 +1,6 @@
 // http://groovy-lang.org/grape.html#Grape-JDBCDrivers
 @GrabConfig(systemClassLoader=true)
-@Grab(group='com.microsoft.sqlserver', module='mssql-jdbc', version='7.2.0.jre8')
+@Grab(group='com.microsoft.sqlserver', module='mssql-jdbc', version='10.2.0.jre17')
 
 import java.net.InetSocketAddress
 import java.sql.Connection

--- a/src/main/groovy/kumc_bmi/StudyTeam.groovy
+++ b/src/main/groovy/kumc_bmi/StudyTeam.groovy
@@ -99,7 +99,7 @@ class CLI {
     String[] args
     
     CLI(args_given) {
-      this.logger.warning(args_given)
+      this.logger.warning(args_given.toSring())
       this.args = raw_args
     }
 

--- a/src/main/groovy/kumc_bmi/StudyTeam.groovy
+++ b/src/main/groovy/kumc_bmi/StudyTeam.groovy
@@ -97,7 +97,7 @@ class CLI {
     String[] args
     
     CLI(args_given) {          
-        this.args = args_given
+        this.args = Eval.me(args_given)
     }
 
     boolean flag(String it) {

--- a/src/main/groovy/kumc_bmi/StudyTeam.groovy
+++ b/src/main/groovy/kumc_bmi/StudyTeam.groovy
@@ -97,9 +97,10 @@ class StudyTeam {
 class CLI {
     String[] args
     
-    CLI(args_given) {          
+    CLI(args_given) {
       def raw_args = Eval.me(args_given.toString())
       assert raw_args.class == String[]  
+      logger.critical(raw_args)
       this.args = raw_args
     }
 

--- a/src/main/groovy/kumc_bmi/StudyTeam.groovy
+++ b/src/main/groovy/kumc_bmi/StudyTeam.groovy
@@ -97,7 +97,7 @@ class CLI {
     String[] args
     
     CLI(args_given) {          
-        this.args = args.addAll(args_given)
+        this.args = args
     }
 
     boolean flag(String it) {

--- a/src/main/groovy/kumc_bmi/StudyTeam.groovy
+++ b/src/main/groovy/kumc_bmi/StudyTeam.groovy
@@ -97,7 +97,7 @@ class CLI {
     String[] args
     
     CLI(args_given) {          
-        this.args = Eval.me(args_given)
+        this.args = args_given.toString()
     }
 
     boolean flag(String it) {


### PR DESCRIPTION
This script connect e-compliance and figure outs study team. 

When I changed from 2.7 to 4.3, new groovy did not allow to access java.lang.object was not accessible. (Dan was accessing protective parameter ( java.lang.object ) which is not allowed in the latest version)

To fix this 
1. removed '@immutable' which does not allow chiild class and also defines API classes automatically like get and put.
2. Define explicate constructor for class ``, it takes argument from cli and define args
3. groovy provided explicit params for ssl (SSL is turned off since last 10 years and also here.)


MAde chanegs to allow the constructors (explicit) to assitgn the CLI args to the variables and also modify connections string for ecompliance as per new groovy 4.3